### PR TITLE
Add dark mode toggle to dashboard

### DIFF
--- a/app/dashboard/_components/navbar.tsx
+++ b/app/dashboard/_components/navbar.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { ReactNode } from "react";
+import ModeToggle from "./mode-toggle";
 
 export default function DashboardTopNav({ children }: { children: ReactNode }) {
   return (
@@ -73,6 +74,7 @@ export default function DashboardTopNav({ children }: { children: ReactNode }) {
           </SheetContent>
         </Dialog>
         <div className="flex justify-center items-center gap-2 ml-auto">
+          <ModeToggle />
           <UserProfile mini={true} />
         </div>
       </header>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -36,9 +36,8 @@ export default function RootLayout({
       <body className={`font-[-apple-system,BlinkMacSystemFont]antialiased`}>
         <ThemeProvider
           attribute="class"
-          defaultTheme="light"
+          defaultTheme="system"
           enableSystem
-          forcedTheme="light"
           disableTransitionOnChange
         >
           {children}


### PR DESCRIPTION
Add dark mode toggle to the dashboard and enable global theme switching.

---
<a href="https://cursor.com/background-agent?bcId=bc-218f274c-8c3a-4b36-b931-e079ebb63253">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-218f274c-8c3a-4b36-b931-e079ebb63253">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

